### PR TITLE
Support Top-k query on shortest.ts

### DIFF
--- a/src/neo4j.ts
+++ b/src/neo4j.ts
@@ -22,7 +22,15 @@ function shortest_cypher(query: any, k: number | string, m: number): string {
     if (k !== "*" || m !== 0) {
         iteration = m.toString() + ".." + k.toString()
     }
-    return `MATCH p=shortestPath((start${from_node_label} ${from_node_props})-[${edge_label}${iteration}]-(end${to_node_label} ${to_node_props})) RETURN p`
+    let topk = query.topk ? parseInt(query.topk) : 1;
+    if (Number.isNaN(topk) || topk <= 0) {
+        topk = 1
+    }
+    if (topk === 1) {
+        return `MATCH p=shortestPath((start${from_node_label} ${from_node_props})-[${edge_label}${iteration}]-(end${to_node_label} ${to_node_props})) RETURN p`
+    } else {
+        return `MATCH p=allShortestPath((start${from_node_label} ${from_node_props})-[${edge_label}${iteration}]-(end${to_node_label} ${to_node_props})) ORDER BY LENGTH(path) ASC LIMIT ${topk}`
+    }
 }
 
 

--- a/src/neo4j.ts
+++ b/src/neo4j.ts
@@ -29,7 +29,7 @@ function shortest_cypher(query: any, k: number | string, m: number): string {
     if (topk === 1) {
         return `MATCH p=shortestPath((start${from_node_label} ${from_node_props})-[${edge_label}${iteration}]-(end${to_node_label} ${to_node_props})) RETURN p`
     } else {
-        return `MATCH p=allShortestPath((start${from_node_label} ${from_node_props})-[${edge_label}${iteration}]-(end${to_node_label} ${to_node_props})) RETURN p ORDER BY LENGTH(p) ASC LIMIT ${topk}`
+        return `MATCH p=allShortestPaths((start${from_node_label} ${from_node_props})-[${edge_label}${iteration}]-(end${to_node_label} ${to_node_props})) RETURN p ORDER BY LENGTH(p) ASC LIMIT ${topk}`
     }
 }
 

--- a/src/neo4j.ts
+++ b/src/neo4j.ts
@@ -29,7 +29,7 @@ function shortest_cypher(query: any, k: number | string, m: number): string {
     if (topk === 1) {
         return `MATCH p=shortestPath((start${from_node_label} ${from_node_props})-[${edge_label}${iteration}]-(end${to_node_label} ${to_node_props})) RETURN p`
     } else {
-        return `MATCH p=allShortestPath((start${from_node_label} ${from_node_props})-[${edge_label}${iteration}]-(end${to_node_label} ${to_node_props})) ORDER BY LENGTH(path) ASC LIMIT ${topk}`
+        return `MATCH p=allShortestPath((start${from_node_label} ${from_node_props})-[${edge_label}${iteration}]-(end${to_node_label} ${to_node_props})) RETURN p ORDER BY LENGTH(p) ASC LIMIT ${topk}`
     }
 }
 

--- a/src/neo4j.ts
+++ b/src/neo4j.ts
@@ -188,7 +188,7 @@ function shortest_opts(query: any, k: number, m: number, limit: number): any {
     return ({
         method: 'POST',
         body: JSON.stringify({"statements" : [ {
-            "statement" : (limit > 0) ? `${q} LIMIT ${limit}` : q,
+            "statement" : (limit > 0) ? `${q}` : q,
             "resultDataContents" : [ "row", "graph" ]
         }]}).replace(/\\"/g, '\\"'),
         headers: {'Content-Type': 'application/json', 'accept': 'application/json', 'Authorization': 'Basic bmVvNGo6bmVvNGp0ZXN0'}

--- a/src/neo4j.ts
+++ b/src/neo4j.ts
@@ -188,7 +188,7 @@ function shortest_opts(query: any, k: number, m: number, limit: number): any {
     return ({
         method: 'POST',
         body: JSON.stringify({"statements" : [ {
-            "statement" : (limit > 0) ? `${q}` : q,
+            "statement" : q,
             "resultDataContents" : [ "row", "graph" ]
         }]}).replace(/\\"/g, '\\"'),
         headers: {'Content-Type': 'application/json', 'accept': 'application/json', 'Authorization': 'Basic bmVvNGo6bmVvNGp0ZXN0'}

--- a/src/shortest.ts
+++ b/src/shortest.ts
@@ -49,15 +49,20 @@ var router = express.Router()
  *         in: "query"
  *       - name: max_hops
  *         in: "query"
- *         description: the number of maximum hops (>=0).
+ *         description: The number of maximum hops (>=0).
  *         type: integer
  *       - name: min_hops
  *         in: "query"
- *         description: the number of minimum hops (>=0).
+ *         description: The number of minimum hops (>=0).
  *         type: integer
+ *       - name: topk
+ *         in: "query"
+ *         description: Retrieve the top-k shortest path.
+ *         type: integer
+ *         default: 1
  *       - name: limit
  *         in: "query"
- *         description: limit records of graph.
+ *         description: Limit records of graph.
  *         type: integer
  *         default: 1000
  *       - name: debug


### PR DESCRIPTION
Currently top-k shortest path is not supported on Cypher query, though it is possible to define the specification.